### PR TITLE
feat: added option to custom environment folder path

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,12 +2,12 @@ const fs = require("fs")
 
 exports.onCreateWebpackConfig = async (
   { actions, plugins, reporter },
-  { envFolderPath = "env/" }
+  { envFolderPath = "env/", customEnvFolderPath}
 ) => {
   const activeEnv =
     process.env.BUILD_ENV || process.env.NODE_ENV || "development"
   const theme = process.env.THEME || null
-  const basePath = `${process.cwd()}/${envFolderPath}`
+  const basePath = customEnvFolderPath ?? `${process.cwd()}/${envFolderPath}`
   async function getEnvs(fileName) {
     const envsPromise = require(`${basePath}${fileName}`)
     const envs = await Promise.resolve(envsPromise)


### PR DESCRIPTION
Hi @luanbitar!

The `envFolderPath` option does not allow declaring a path from an address other than where the build process is running. In a monorepo structure, with yarn workspaces for example, it would be possible to declare folders above, making more easier to reuse code.

What do you think?